### PR TITLE
.github: Fix clang-format not finding the source code

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Clang
       run: |
-        sudo apt-get install -y clang-format-12
-        clang-format -i -fallback-style=none $(git ls-files | grep '\.\(c\|h\)$')
+        sudo apt-get install -y clang-format-18
+        clang-format -i -fallback-style=none $(git ls-files | grep '\.\(cpp\|c\|h\)$')
 
     - name: Check
       # Build your program with the given configuration


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

Fixed the regex to select source code so that clang-format will now checks the source code.
Also upgrade clang-format version.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

CI

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
